### PR TITLE
Fix bug where text tags merged with choice tags.

### DIFF
--- a/nomicon/impl/ChoicePoint.lua
+++ b/nomicon/impl/ChoicePoint.lua
@@ -54,30 +54,30 @@ function ChoicePoint:call(executor)
 
     local startChoiceText, endChoiceText
 
-    local tags = {}
-    do
-        local outputStack = executor:getOutputStack()
-        for i = 1, outputStack:getCount() do
-            local value = outputStack:peek(i)
-            if value:is(Constants.TYPE_TAG) then
-                local tag = Utility.cleanWhitespace(value:cast(Constants.TYPE_STRING))
-                table.insert(tags, tag)
-            else
-                break
-            end
-        end
-
-        for _ = 1, #tags do
-            outputStack:remove(1)
-        end
-    end
-
     if self:getHasEndContent() then
         endChoiceText = stack:pop():cast(Constants.TYPE_STRING) or ""
     end
 
     if self:getHasStartContent() then
         startChoiceText = stack:pop():cast(Constants.TYPE_STRING) or ""
+    end
+
+    local tags = {}
+    do
+        local outputStack = executor:getOutputStack()
+        for i = outputStack:getCount(), 1, -1 do
+            local value = outputStack:peek(i)
+            if value:is(Constants.TYPE_TAG) then
+                local tag = Utility.cleanWhitespace(value:cast(Constants.TYPE_STRING))
+                table.insert(tags, 1, tag)
+            else
+                break
+            end
+        end
+
+        if #tags > 0 then
+            outputStack:pop(#tags)
+        end
     end
 
     local targetContainer = executor:getPointer(self._targetContainer)

--- a/tests/manual/test_itsyrealm_tags.ink
+++ b/tests/manual/test_itsyrealm_tags.ink
@@ -1,0 +1,6 @@
+# speaker=Orlando
+WREN! TALK TO ME!
+
+* ...
+
+-> DONE

--- a/tests/manual/tests.lua
+++ b/tests/manual/tests.lua
@@ -19,6 +19,14 @@ local function test(description, func)
     })
 end
 
+test("itsyrealm tags bug", function()
+    local story = loadStory("test_itsyrealm_tags")
+
+    lu.assertEquals(story:continue(), "WREN! TALK TO ME!\n")
+    lu.assertEquals(story:getTagCount(), 1)
+    lu.assertEquals(story:getTag(1), "speaker=Orlando")
+end)
+
 test("should test default global variables", function()
     local story = loadStory("should_test_default_global_variables", { to_be_overwritten = "I'm a human bean!" })
     lu.assertEquals(story:continue(), "I'm a human bean!\n")


### PR DESCRIPTION
**Observed behavior**: In the example `test_itsyrealm_tags`, the `...` choice would have the `speaker=Orlando` tags, while the text `WREN! TALK TO ME!` would have no tags.

**Expected behavior**: The `...` choice would have no tags, while the text `WREN! TALK TO ME!` would have the `speaker=Orlando` tag.